### PR TITLE
Performance by year takes optional "kind" which is flavor of data simulated

### DIFF
--- a/data.py
+++ b/data.py
@@ -13,7 +13,7 @@ import json
 import sys
 from collections import defaultdict
 
-from configure import configure, in_shutdown, run_model
+from configure import configure, in_shutdown, mc_event_model, run_model
 from plotting import plotStorage, plotStorageWithCapacity
 from utils import performance_by_year, time_dependent_value
 
@@ -91,11 +91,14 @@ for tier in TIERS:
 # Loop over years to determine how much is produced without versions or replicas
 for year in YEARS:
     for tier in TIERS:
-        dummyCPU, tierSize = performance_by_year(model, year, tier)
         if tier not in model['mc_only_tiers']:
+            dummyCPU, tierSize = performance_by_year(model, year, tier, data_type='data')
             dataProduced[year]['data'][tier] += tierSize * run_model(model, year, data_type='data').events
         if tier not in model['data_only_tiers']:
-            dataProduced[year]['mc'][tier] += tierSize * run_model(model, year, data_type='mc').events
+            mcEvents = mc_event_model(model, year)
+            for kind, events in mcEvents.items():
+                dummyCPU, tierSize = performance_by_year(model, year, tier, data_type='mc', kind=kind)
+                dataProduced[year]['mc'][tier] += tierSize * events
 
 producedByTier = [[0 for _i in range(len(TIERS))] for _j in YEARS]
 for year, dataDict in dataProduced.items():

--- a/utils.py
+++ b/utils.py
@@ -8,7 +8,7 @@ Common code between various models
 from __future__ import absolute_import, division, print_function
 
 
-def performance_by_year(model, year, tier, data_type=None):
+def performance_by_year(model, year, tier, data_type=None, kind=None):
     """
     Return various performance metrics based on the year under consideration
     (allows for step and continuous variations)
@@ -17,13 +17,18 @@ def performance_by_year(model, year, tier, data_type=None):
     :param year: The year in which processing is done
     :param tier: Data tier produced
     :param data_type: data or mc
+    :param kind: The year flavor of MC or data. May differ from actual running year
 
     :return:  tuple of cpu time (HS06) and data size
     """
 
+    # If we don't specify flavors, assume we are talking about the current year
+    if not kind:
+        kind = year
+
     try:
         for modelYear in sorted(model['tier_sizes'][tier].keys()):
-            if int(year) >= int(modelYear):
+            if int(kind) >= int(modelYear):
                 sizePerEvent = model['tier_sizes'][tier][modelYear]
     except KeyError:  # Storage model does not know this tier
         sizePerEvent = None
@@ -31,10 +36,10 @@ def performance_by_year(model, year, tier, data_type=None):
     try:
         # Look up the normalized processing time
         for modelYear in sorted(model['cpu_time'][data_type][tier].keys()):
-            if int(year) >= int(modelYear):
+            if int(kind) >= int(modelYear):
                 cpuPerEvent = model['cpu_time'][data_type][tier][modelYear]
 
-                # Apply the year by year correction
+        # Apply the year by year correction
         cpuPerEvent = cpuPerEvent / (model['improvement_factors']['software']) ** (1 + year - model['start_year'])
     except KeyError:  # CPU model does not know this tier
         cpuPerEvent = None


### PR DESCRIPTION
2017 for LHC
2026 for HL-LHC

@kenbloom this should do it. You can see the change I made to data.py (nee disk.py) to get the different flavors.