### PR TITLE
Many changes to CPU model; see below

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -19,7 +19,7 @@ def performance_by_year(model, year, tier, data_type=None, kind=None):
     :param data_type: data or mc
     :param kind: The year flavor of MC or data. May differ from actual running year
 
-    :return:  tuple of cpu time (HS06) and data size
+    :return:  tuple of cpu time (HS06 * s) and data size
     """
 
     # If we don't specify flavors, assume we are talking about the current year


### PR DESCRIPTION
Bug fix in shutdown model that screwed up rereco time needed
Change units of computing time from MHS06 years to THS06 s
Change in-year data reprocessing from 10% to 25% of data
Add a year of data reprocessing in each running year to represent last year's reprocessing
For capacity calculations, use the max of the two above things, as they won't happen at the same time
Recalibrate analysis to be 75% of everything else, to tune this to the 2018 resource request